### PR TITLE
fix jet id bitwise bug for 17/18

### DIFF
--- a/processors/HNL.py
+++ b/processors/HNL.py
@@ -82,6 +82,11 @@ if args.isData:
                2018: 'Autumn18_V19_DATA'
                }
 
+met_variable = {2016: lambda event: Object(event, "MET"),
+                2017: lambda event: Object(event, "METFixEE2017"),
+                2018: lambda event: Object(event, "MET")
+                }
+
 
 leptonSelection = [
     EventSkim(selection=lambda event: event.nTrigObj > 0),
@@ -213,6 +218,7 @@ analyzerChain.append(
 if isMC:
     analyzerChain.append(
         JetMetUncertainties(
+            metInput=met_variable[year],
             jesUncertaintyFile=jesUncertaintyFile[year],
             jerResolutionFileName=jerResolutionFile[year],
             jerSFUncertaintyFileName=jerSFUncertaintyFile[year],
@@ -464,6 +470,7 @@ else:
     analyzerChain.extend([
         WbosonReconstruction(
             leptonCollectionName='leadingLeptons',
+            metObject=met_variable[year],
             globalOptions=globalOptions,
             outputName="nominal"
         )
@@ -473,6 +480,7 @@ else:
         EventObservables(
             jetCollection=lambda event: event.selectedJets_nominal,
             leptonCollection=lambda event: event.leadingLeptons[0],
+            metInput=met_variable[year],
             globalOptions=globalOptions,
             outputName="EventObservables_nominal"
         )

--- a/python/modules/JetSelection.py
+++ b/python/modules/JetSelection.py
@@ -30,10 +30,11 @@ class JetSelection(Module):
          dRP4Subtraction=0.4,
          flagDA=False,
          storeKinematics=['pt', 'eta'],
-         globalOptions={"isData": False},
+         globalOptions={"isData": False, "year": 2016},
          jetId=LOOSE
      ):
         self.globalOptions = globalOptions
+
         self.inputCollection = inputCollection
         self.leptonCollectionDRCleaning = leptonCollectionDRCleaning
         self.leptonCollectionP4Subraction = leptonCollectionP4Subraction
@@ -45,7 +46,10 @@ class JetSelection(Module):
         self.dRP4Subtraction = dRP4Subtraction
         self.flagDA = flagDA
         self.storeKinematics = storeKinematics
-        self.jetId = jetId
+        if jetId==JetSelection.LOOSE and (globalOptions["year"] == 2017 or globalOptions["year"] == 2018):
+            self.jetId = JetSelection.TIGHT
+        else:
+            self.jetId = jetId
 
     def beginJob(self):
         pass


### PR DESCRIPTION
* For 17/18, loose jet id does not exist, this causes all jets to be rejected if loose id is required
* For 2017, an alternative missing pT with the EE noise mitigation applied is provided in branches METFixEE2017_. Except for this mitigation, it is defined in the same way as the default missing pT (MET_).