### PR TITLE
Tagger switch

### DIFF
--- a/processors/HNL.py
+++ b/processors/HNL.py
@@ -507,12 +507,12 @@ else:
         )
     )
 
-    analyzerChain.append(
-        PileupWeight(
-            outputName="puweight",
-            globalOptions=globalOptions
-        )
+analyzerChain.append(
+    PileupWeight(
+        outputName="puweight",
+        globalOptions=globalOptions
     )
+)
 
 storeVariables = [
     [lambda tree: tree.branch("PV_npvs", "I"), lambda tree,

--- a/processors/HNL.py
+++ b/processors/HNL.py
@@ -547,11 +547,7 @@ if testMode:
             analyzerChain.pop(ianalyzer)   
 
 if args.noTagger:
-    analyzerChainNew = analyzerChain
-    for ianalyzer, analyzer in enumerate(analyzerChain):
-        if type(analyzer).__name__ not in taggerTypes:
-            analyzerChainNew.append(analyzer)
-    analyzerChain = analyzerChainNew
+    analyzerChain = ([module for module in analyzerChain if type(module).__name__ not in taggerTypes])
 
 p = PostProcessor(
     args.output[0],

--- a/python/modules/LeptonCollecting.py
+++ b/python/modules/LeptonCollecting.py
@@ -76,16 +76,16 @@ class LeptonCollecting(Module):
             lepton.isElectron = 1
             lepton.relIso = lepton.pfRelIso03_all
 
-        tightLepton = []
+        tightLeptons = []
         looseLeptons = []
 
-        tightLepton = tightMuon+tightElectron
+        tightLeptons = tightMuon+tightElectron
         looseLeptons = looseMuons+looseElectrons
 
-        tightLepton = sorted(tightLepton, key=lambda x: x.pt, reverse=True)
+        tightLeptons = sorted(tightLeptons, key=lambda x: x.pt, reverse=True)
         # select leading only, move subleading to "loose"
         looseLeptons.extend(tightLepton[1:])
-        tightLeptons = [tightLepton[0]]
+        tightLeptons = [tightLeptons[0]]
         looseLeptons = sorted(looseLeptons, key=lambda x: x.pt, reverse=True)
 
         muonmuon = 0
@@ -98,21 +98,21 @@ class LeptonCollecting(Module):
         ## flavour categorisation :
 
         if len(looseLeptons) > 0:
-            if tightLepton[0].isMuon and looseLepton[0].isMuon == 1:
+            if tightLeptons[0].isMuon and looseLeptons[0].isMuon == 1:
                 muonmuon = 1
             
-            elif tightLepton[0].isElectron and looseLepton[0].isElectron == 1:
+            elif tightLeptons[0].isElectron and looseLeptons[0].isElectron == 1:
                 electronelectron= 1
 
-            elif tightLepton[0].isMuon and looseLepton[0].isElectron == 1:
+            elif tightLeptons[0].isMuon and looseLeptons[0].isElectron == 1:
                 muonelectron = 1
 
-            elif tightLepton[0].isElectron and looseLepton[0].isMuon == 1:
+            elif tightLeptons[0].isElectron and looseLeptons[0].isMuon == 1:
                 electronmuon = 1
 
-        elif tightLepton[0].isMuon:
+        elif tightLeptons[0].isMuon:
             muonjets = 1 
-        elif tightLepton[0].isElectron:
+        elif tightLeptons[0].isElectron:
             electronjets = 1 
 
         if muonmuon or muonelectron or muonjets:

--- a/python/modules/LeptonCollecting.py
+++ b/python/modules/LeptonCollecting.py
@@ -84,7 +84,7 @@ class LeptonCollecting(Module):
 
         tightLeptons = sorted(tightLeptons, key=lambda x: x.pt, reverse=True)
         # select leading only, move subleading to "loose"
-        looseLeptons.extend(tightLepton[1:])
+        looseLeptons.extend(tightLeptons[1:])
         tightLeptons = [tightLeptons[0]]
         looseLeptons = sorted(looseLeptons, key=lambda x: x.pt, reverse=True)
 
@@ -98,16 +98,16 @@ class LeptonCollecting(Module):
         ## flavour categorisation :
 
         if len(looseLeptons) > 0:
-            if tightLeptons[0].isMuon and looseLeptons[0].isMuon == 1:
+            if tightLeptons[0].isMuon and looseLeptons[0].isMuon:
                 muonmuon = 1
             
-            elif tightLeptons[0].isElectron and looseLeptons[0].isElectron == 1:
+            elif tightLeptons[0].isElectron and looseLeptons[0].isElectron:
                 electronelectron= 1
 
-            elif tightLeptons[0].isMuon and looseLeptons[0].isElectron == 1:
+            elif tightLeptons[0].isMuon and looseLeptons[0].isElectron:
                 muonelectron = 1
 
-            elif tightLeptons[0].isElectron and looseLeptons[0].isMuon == 1:
+            elif tightLeptons[0].isElectron and looseLeptons[0].isMuon:
                 electronmuon = 1
 
         elif tightLeptons[0].isMuon:

--- a/test/runCMSSWTest.sh
+++ b/test/runCMSSWTest.sh
@@ -17,6 +17,7 @@ function run_test()
     #python PhysicsTools/NanoAODTools/processors/HNL.py --year 2017 --testMode --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_HNL_nanoAODv2p1.root . || return 1
     #python PhysicsTools/NanoAODTools/processors/HNL.py --year 2018 --testMode --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_HNL_nanoAODv2p1.root . || return 1
     python PhysicsTools/NanoAODTools/processors/HNL.py --testMode --isData --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_data_nanoAODv2p1.root . || return 1
+    python PhysicsTools/NanoAODTools/processors/HNL.py --testMode --noTagger --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_data_nanoAODv2p1.root . || return 1
     #python PhysicsTools/NanoAODTools/processors/skimForDA.py --isData --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_data_nanoAODv2p1.root . || return 1
 }
 

--- a/test/runCMSSWTest.sh
+++ b/test/runCMSSWTest.sh
@@ -14,11 +14,9 @@ function run_test()
     echo "--- Test HNL script ---"
     # add data test
     python PhysicsTools/NanoAODTools/processors/HNL.py --year 2016 --testMode --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_HNL_nanoAODv2p1.root . || return 1
-    #python PhysicsTools/NanoAODTools/processors/HNL.py --year 2017 --testMode --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_HNL_nanoAODv2p1.root . || return 1
-    #python PhysicsTools/NanoAODTools/processors/HNL.py --year 2018 --testMode --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_HNL_nanoAODv2p1.root . || return 1
+    python PhysicsTools/NanoAODTools/processors/HNL.py --year 2016 --testMode --noTagger --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_HNL_nanoAODv2p1.root . || return 1
     python PhysicsTools/NanoAODTools/processors/HNL.py --testMode --isData --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_data_nanoAODv2p1.root . || return 1
-    python PhysicsTools/NanoAODTools/processors/HNL.py --testMode --noTagger --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_data_nanoAODv2p1.root . || return 1
-    #python PhysicsTools/NanoAODTools/processors/skimForDA.py --isData --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_data_nanoAODv2p1.root . || return 1
+    python PhysicsTools/NanoAODTools/processors/HNL.py --testMode --isData --noTagger --input=https://github.com/LLPDNNX/test-files/raw/master/nanoaod/Moriond17_aug2018_miniAODv3_data_nanoAODv2p1.root . || return 1
 }
 
 run_test


### PR DESCRIPTION
* Add a switch to not run the tagger part, just the event kinematics (useful for making tuples to check data/MC agreement, or train BDT)
* Move some part of event categorisation to the lepton collecting module (it's independent of tagger!)